### PR TITLE
Fix IndexError: pop from empty list

### DIFF
--- a/src/uhid/__init__.py
+++ b/src/uhid/__init__.py
@@ -370,10 +370,14 @@ class AsyncioBlockingUHID(_BlockingUHIDBase):
         self._loop.add_reader(self._uhid, self._read)
 
     def _async_writer(self) -> None:
-        self._write(self._write_queue.pop(0))
-        if not self._write_queue:
-            self._loop.remove_writer(self._uhid)
-            self._writer_registered = False
+        try:
+            self._write(self._write_queue.pop(0))
+        except IndexError:
+            self.__logger.info("writer: queue empty")
+        finally:
+            if not self._write_queue:
+                self._loop.remove_writer(self._uhid)
+                self._writer_registered = False
 
     def _send_event(self, event: bytes) -> None:
         # TODO: benchmark loop.add_writer vs plain write, I feel plain write should be faster in the UHID fd


### PR DESCRIPTION
The program ended up consuming a lot of CPU time and spewing this error:

```
IndexError: pop from empty list
12:01:48.086 Exception in callback AsyncioBlockingUHID._async_writer()
handle: <Handle AsyncioBlockingUHID._async_writer()>
Traceback (most recent call last):
  File "/usr/lib/python3.12/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/lib/python3/dist-packages/fido2ble/vendored/uhid/__init__.py", line 374, in _async_writer
    self._write(self._write_queue.pop(0))
                ^^^^^^^^^^^^^^^^^^^^^^^^
```

If the list is empty, the exception was preventing the removal of the writer.

Closes #6
